### PR TITLE
fix: handle timeout errors in preinstall.js

### DIFF
--- a/preinstall.js
+++ b/preinstall.js
@@ -5,7 +5,7 @@
 let http = require('http');
 let fs = require('fs');
 
-http.get('http://prefix.cc/context', (res) => {
+const request = http.get('http://prefix.cc/context', (res) => {
   const { statusCode } = res;
 
   if (statusCode === 200) {
@@ -23,3 +23,14 @@ http.get('http://prefix.cc/context', (res) => {
     });
   }
 });
+
+request.on('error', (err) => {
+  if (!isCompleted) {
+    isCompleted = true;
+    console.error('Request error:', err.message);
+    console.error('Error code:', err.code);
+    console.error('Failed to fetch data from http://prefix.cc/context');
+    process.exit(0);
+  }
+});
+


### PR DESCRIPTION
occasional timeouts in the request of preinstall.js break a CI script that installs yarrrml-parser which depends on prefix-ns - if the timeout is handled gracefully then hopefully the script will fall back to the hard-coded data.json 